### PR TITLE
Correction compilation frontend

### DIFF
--- a/front-src/src/app/components/backlog/create-issue/create-issue.component.ts
+++ b/front-src/src/app/components/backlog/create-issue/create-issue.component.ts
@@ -65,6 +65,8 @@ export class CreateIssueComponent implements OnInit {
     this.message = message;
     this.isError = false;
   }
+
+  ngOnInit() { }
 }
 interface CreateIssueResponse
 {


### PR DESCRIPTION
Ceci corrige l'erreur suivante

frontend_1  | ERROR in src/app/components/backlog/create-issue/create-issue.component.ts(16,14): error TS2420: Class 'CreateIssueComponent' incorrectly implements interface 'OnInit'.
frontend_1  |   Property 'ngOnInit' is missing in type 'CreateIssueComponent'.